### PR TITLE
Add privacy policy for App Store submission

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,0 +1,127 @@
+# Privacy Policy
+
+**Luego - Read It Later**
+
+*Last Updated: November 26, 2025*
+
+## Overview
+
+Luego ("the App") is a read-it-later application that allows you to save articles for offline reading. Your privacy is important to us. This Privacy Policy explains what information we collect, how we use it, and what choices you have.
+
+**The short version:** Luego is designed with privacy in mind. All your data stays on your device. We don't collect, store, or share any personal information.
+
+## Information We Collect
+
+### Information You Provide
+
+When you use Luego, you save article URLs to your reading list. The App stores the following information **locally on your device only**:
+
+- **Article URLs** - The web addresses you save
+- **Article metadata** - Titles, descriptions, publication dates, and thumbnail images extracted from saved URLs
+- **Article content** - The text content extracted from articles when you read them
+- **Reading progress** - Your scroll position within articles
+- **User preferences** - Whether you've marked articles as favorites or archived
+
+### Information We Do NOT Collect
+
+- No personal identifiers (name, email, phone number)
+- No device identifiers
+- No location data
+- No usage analytics or telemetry
+- No advertising identifiers
+- No health, financial, or biometric data
+
+## How We Use Information
+
+All data processing happens **locally on your device**:
+
+1. **Fetching article content** - When you save a URL, the App downloads the webpage directly to extract metadata and content
+2. **Storing your reading list** - Articles are saved to your device's local storage using Apple's SwiftData framework
+3. **Share Extension** - When you share URLs from Safari or other apps, they are temporarily stored in a local App Group container until synced to your main reading list
+
+## Data Storage
+
+- **Location**: All data is stored exclusively on your device
+- **Cloud sync**: None - Luego does not sync data to any cloud service
+- **Backups**: Your data may be included in device backups (iCloud or local) if you have backups enabled
+- **Encryption**: Data is protected by your device's built-in security features
+
+## Third-Party Services
+
+### No Third-Party Analytics or Tracking
+
+Luego does not include any:
+- Analytics services
+- Crash reporting services
+- Advertising networks
+- Social media trackers
+
+### Open Source Libraries
+
+The App uses the following open-source libraries for local processing only:
+
+- **SwiftSoup** - For parsing HTML content (MIT License)
+- **MarkdownUI** - For rendering article content (MIT License)
+
+These libraries operate entirely on your device and do not transmit any data externally.
+
+### Network Requests
+
+The only network requests Luego makes are:
+- **Direct requests to article URLs** - To download webpage content from URLs you explicitly save
+
+We do not operate any servers that receive your data.
+
+## Data Sharing
+
+**We do not share your data with anyone.**
+
+Since all data remains on your device and we have no access to it, there is nothing to share with third parties.
+
+## Data Retention and Deletion
+
+- **Retention**: Articles remain in your reading list until you delete them
+- **Deletion**: You can delete individual articles at any time by swiping or using the delete option
+- **App removal**: Uninstalling the App removes all associated data from your device
+
+## Children's Privacy
+
+Luego does not knowingly collect information from children under 13. The App does not collect any personal information from any users.
+
+## Your Rights and Choices
+
+You have complete control over your data:
+
+- **Access**: All your data is accessible directly within the App
+- **Delete**: Remove any article or clear your entire reading list at any time
+- **Export**: Data remains on your device and can be backed up through your device's backup system
+
+## Security
+
+Luego relies on iOS security features to protect your data:
+
+- Data stored using Apple's secure SwiftData framework
+- App sandboxing prevents other apps from accessing your data
+- No network transmission of personal data
+
+## Changes to This Policy
+
+We may update this Privacy Policy from time to time. We will notify you of any changes by updating the "Last Updated" date at the top of this policy.
+
+## App Store Privacy Details
+
+For Apple's App Privacy disclosures:
+
+- **Data Not Collected**: Luego does not collect any data
+- **Data Not Linked to You**: No data is linked to your identity
+- **Data Not Used to Track You**: No tracking across apps or websites
+
+## Contact Us
+
+If you have questions about this Privacy Policy or the App's privacy practices, please contact us at:
+
+**Email**: [Your Contact Email]
+
+---
+
+*This privacy policy is effective as of November 26, 2025.*


### PR DESCRIPTION
Create comprehensive privacy policy documenting that:
- All data is stored locally on device only
- No analytics, tracking, or advertising
- No cloud sync or server-side storage
- Only network requests are to fetch user-provided URLs
- Users have full control to delete their data