### PR TITLE
feat(settings): add SDK update check with version feedback

### DIFF
--- a/Luego/Features/Settings/Views/SettingsView.swift
+++ b/Luego/Features/Settings/Views/SettingsView.swift
@@ -16,6 +16,11 @@ struct SettingsView: View {
                 onRefresh: viewModel.refreshArticlePool
             )
 
+            SDKUpdateSection(
+                isChecking: viewModel.isCheckingForUpdates,
+                onCheck: { Task { await viewModel.checkForSDKUpdates() } }
+            )
+
             AppVersionSection(sdkVersionString: viewModel.sdkVersionString)
         }
         .navigationTitle("Settings")
@@ -23,6 +28,14 @@ struct SettingsView: View {
             ToolbarItem(placement: .confirmationAction) {
                 Button("Done") { dismiss() }
             }
+        }
+        .alert(
+            viewModel.updateAlertTitle,
+            isPresented: $viewModel.showUpdateAlert
+        ) {
+            Button("OK") { }
+        } message: {
+            Text(viewModel.updateAlertMessage)
         }
     }
 }
@@ -126,6 +139,31 @@ struct RefreshArticlePoolSection: View {
             .disabled(didRefresh)
         } footer: {
             Text("Clears the cached article pool and fetches fresh articles on next discovery.")
+        }
+    }
+}
+
+struct SDKUpdateSection: View {
+    let isChecking: Bool
+    let onCheck: () -> Void
+
+    var body: some View {
+        Section {
+            Button(action: onCheck) {
+                HStack {
+                    Label("Check for SDK Updates", systemImage: "arrow.triangle.2.circlepath")
+
+                    Spacer()
+
+                    if isChecking {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                }
+            }
+            .disabled(isChecking)
+        } footer: {
+            Text("Downloads the latest parsing rules and parser if available.")
         }
     }
 }

--- a/Luego/Features/Settings/Views/SettingsViewModel.swift
+++ b/Luego/Features/Settings/Views/SettingsViewModel.swift
@@ -5,6 +5,9 @@ import Foundation
 final class SettingsViewModel {
     var selectedDiscoverySource: DiscoverySource
     var didRefreshPool = false
+    var isCheckingForUpdates = false
+    var updateResult: SDKUpdateResult?
+    var showUpdateAlert = false
 
     private let preferencesDataSource: DiscoveryPreferencesDataSourceProtocol
     private let discoveryService: DiscoveryServiceProtocol
@@ -34,5 +37,37 @@ final class SettingsViewModel {
     func refreshArticlePool() {
         discoveryService.clearAllCaches()
         didRefreshPool = true
+    }
+
+    func checkForSDKUpdates() async {
+        isCheckingForUpdates = true
+        updateResult = await sdkManager.checkForUpdates()
+        isCheckingForUpdates = false
+        showUpdateAlert = true
+    }
+
+    var updateAlertTitle: String {
+        guard let result = updateResult else { return "" }
+        switch result {
+        case .updated: return "SDK Updated"
+        case .alreadyUpToDate: return "Up to Date"
+        case .failed: return "Update Failed"
+        }
+    }
+
+    var updateAlertMessage: String {
+        guard let result = updateResult else { return "" }
+        switch result {
+        case .updated(let parser, let rules, let bundlesUpdated, let rulesUpdated):
+            var components: [String] = []
+            if bundlesUpdated > 0 { components.append("\(bundlesUpdated) bundle(s)") }
+            if rulesUpdated { components.append("rules") }
+            let updatedText = components.isEmpty ? "" : "\nUpdated: \(components.joined(separator: ", "))"
+            return "Parser \(parser) · Rules \(rules)\(updatedText)"
+        case .alreadyUpToDate(let parser, let rules):
+            return "Parser \(parser) · Rules \(rules)"
+        case .failed(let error):
+            return error.localizedDescription
+        }
     }
 }

--- a/LuegoTests/TestSupport/Mocks/DataSources/MockLuegoSDKManager.swift
+++ b/LuegoTests/TestSupport/Mocks/DataSources/MockLuegoSDKManager.swift
@@ -4,6 +4,7 @@ import Foundation
 @MainActor
 final class MockLuegoSDKManager: LuegoSDKManagerProtocol {
     var ensureSDKReadyCallCount = 0
+    var checkForUpdatesCallCount = 0
     var isSDKAvailableCallCount = 0
     var loadBundlesCallCount = 0
     var loadRulesCallCount = 0
@@ -13,9 +14,15 @@ final class MockLuegoSDKManager: LuegoSDKManagerProtocol {
     var bundlesToReturn: [String: String]?
     var rulesToReturn: Data?
     var versionInfoToReturn: SDKVersionInfo?
+    var updateResultToReturn: SDKUpdateResult = .alreadyUpToDate(parserVersion: "1.0.0", rulesVersion: "1.0.0")
 
     func ensureSDKReady() async {
         ensureSDKReadyCallCount += 1
+    }
+
+    func checkForUpdates() async -> SDKUpdateResult {
+        checkForUpdatesCallCount += 1
+        return updateResultToReturn
     }
 
     func isSDKAvailable() -> Bool {
@@ -40,6 +47,7 @@ final class MockLuegoSDKManager: LuegoSDKManagerProtocol {
 
     func reset() {
         ensureSDKReadyCallCount = 0
+        checkForUpdatesCallCount = 0
         isSDKAvailableCallCount = 0
         loadBundlesCallCount = 0
         loadRulesCallCount = 0
@@ -48,5 +56,6 @@ final class MockLuegoSDKManager: LuegoSDKManagerProtocol {
         bundlesToReturn = nil
         rulesToReturn = nil
         versionInfoToReturn = nil
+        updateResultToReturn = .alreadyUpToDate(parserVersion: "1.0.0", rulesVersion: "1.0.0")
     }
 }


### PR DESCRIPTION
Users can now manually check for SDK updates from Settings. Shows loading state during check and displays an alert with the result: updated versions, already up-to-date, or error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)