### PR TITLE
chore(versioning): bump to 2026.01.29 for TestFlight deployment

### DIFF
--- a/Luego.xcodeproj/project.pbxproj
+++ b/Luego.xcodeproj/project.pbxproj
@@ -491,7 +491,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2025.01.29;
+				MARKETING_VERSION = 2026.01.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.esoxjem.Luego;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -527,7 +527,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2025.01.29;
+				MARKETING_VERSION = 2026.01.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.esoxjem.Luego;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -558,7 +558,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2025.01.29;
+				MARKETING_VERSION = 2026.01.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.esoxjem.Luego.LuegoShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -587,7 +587,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2025.01.29;
+				MARKETING_VERSION = 2026.01.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.esoxjem.Luego.LuegoShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -614,7 +614,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2025.01.29;
+				MARKETING_VERSION = 2026.01.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.esoxjem.Luego.LuegoTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -641,7 +641,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2025.01.29;
+				MARKETING_VERSION = 2026.01.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.esoxjem.Luego.LuegoTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;


### PR DESCRIPTION
Bump marketing version to 2026.01.29 across all build targets in preparation for TestFlight deployment.

Version updated for:
- Main Luego app
- LuegoShareExtension
- Test targets

Build number remains at 1.