### PR TITLE
fix(ipad): wire up Inspire Me button to Discovery view

### DIFF
--- a/Luego/App/ContentView.swift
+++ b/Luego/App/ContentView.swift
@@ -38,7 +38,8 @@ struct ContentView: View {
             } content: {
                 ArticleListPane(
                     filter: selectedFilter,
-                    selectedArticle: $selectedArticle
+                    selectedArticle: $selectedArticle,
+                    onDiscover: { selectedFilter = .discovery }
                 )
             } detail: {
                 DetailPane(article: selectedArticle)

--- a/Luego/Features/ReadingList/Views/ArticleListPane.swift
+++ b/Luego/Features/ReadingList/Views/ArticleListPane.swift
@@ -4,6 +4,7 @@ import SwiftData
 struct ArticleListPane: View {
     let filter: ArticleFilter
     @Binding var selectedArticle: Article?
+    let onDiscover: () -> Void
     @Environment(\.diContainer) private var diContainer
     @Query(sort: \Article.savedDate, order: .reverse) private var allArticles: [Article]
     @State private var viewModel: ArticleListViewModel?
@@ -18,7 +19,7 @@ struct ArticleListPane: View {
         Group {
             if let viewModel {
                 if filteredArticles.isEmpty {
-                    ArticleListEmptyState(onDiscover: {}, filter: filter)
+                    ArticleListEmptyState(onDiscover: onDiscover, filter: filter)
                 } else {
                     SelectableArticleList(
                         articles: filteredArticles,
@@ -34,6 +35,12 @@ struct ArticleListPane: View {
         .navigationTitle(filter.title)
         .toolbar {
             ToolbarItemGroup(placement: .primaryAction) {
+                if filter == .readingList {
+                    Button(action: onDiscover) {
+                        Image(systemName: "die.face.5")
+                    }
+                    .accessibilityLabel("Inspire Me")
+                }
                 Button {
                     showingAddArticle = true
                 } label: {

--- a/Luego/Features/ReadingList/Views/ArticleListView.swift
+++ b/Luego/Features/ReadingList/Views/ArticleListView.swift
@@ -41,6 +41,7 @@ struct ArticleListView: View {
                     } label: {
                         Image(systemName: "die.face.5")
                     }
+                    .accessibilityLabel("Inspire Me")
                 }
                 Button {
                     showingAddArticle = true


### PR DESCRIPTION
Fixes the iPad "Inspire Me" button which was previously a no-op. The button now navigates to the Discovery view by switching the sidebar filter, matching the iPhone implementation's functionality.

Also adds accessibility labels to the discovery toolbar buttons on both platforms for VoiceOver support.

**Changes:**
- Pass `onDiscover` callback from ContentView to ArticleListPane
- Wire empty state and toolbar button to trigger discovery navigation
- Add "Inspire Me" accessibility labels to icon-only buttons