### PR TITLE
fix: Add missing macOS entitlements for iCloud sync

### DIFF
--- a/Luego/Luego-macOS.entitlements
+++ b/Luego/Luego-macOS.entitlements
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
 		<string>iCloud.com.esoxjem.Luego</string>
@@ -9,6 +15,10 @@
 	<key>com.apple.developer.icloud-services</key>
 	<array>
 		<string>CloudKit</string>
+	</array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.esoxjem.Luego</string>
 	</array>
 </dict>
 </plist>

--- a/docs/plans/2026-02-07-fix-macos-icloud-sync-missing-entitlements-plan.md
+++ b/docs/plans/2026-02-07-fix-macos-icloud-sync-missing-entitlements-plan.md
@@ -1,0 +1,97 @@
+---
+title: "fix: macOS iCloud Sync Broken Due to Missing Entitlements"
+type: fix
+date: 2026-02-07
+---
+
+# Fix macOS iCloud Sync Broken Due to Missing Entitlements
+
+## Overview
+
+Articles added on iPhone/iPad do not appear on the macOS app. Sync works correctly between iPhone and iPad. The root cause is that `Luego-macOS.entitlements` is missing 3 critical entitlements that were specified in the original macOS support plan but never added during implementation.
+
+## Problem Statement
+
+The macOS entitlements file (`Luego/Luego-macOS.entitlements`) only contains:
+- `com.apple.developer.icloud-container-identifiers`
+- `com.apple.developer.icloud-services`
+
+It is **missing** these entitlements that the iOS version has:
+
+| Entitlement | iOS | macOS | Impact |
+|-------------|-----|-------|--------|
+| `aps-environment` | Yes | **No** | CloudKit uses push notifications to trigger sync. Without this, macOS never receives sync events. |
+| `com.apple.security.app-sandbox` | N/A | **No** | Build settings enable sandbox (`ENABLE_APP_SANDBOX = YES`) but the entitlements file doesn't declare it, creating a mismatch. |
+| `com.apple.security.network.client` | N/A | **No** | Required for network access in sandboxed macOS apps. CloudKit needs this to talk to iCloud servers. |
+| `com.apple.security.application-groups` | Yes | **No** | Needed for Share Extension data sharing (not directly related to sync, but should be present for parity). |
+
+## Root Cause
+
+The original plan (`docs/plans/2026-01-30-feat-macos-native-support-plan.md`) specified the correct entitlements including `app-sandbox` and `network.client`, but the implementation only added the two iCloud-specific keys. A follow-up todo (`todos/003-resolved-p2-missing-sandbox-entitlements.md`) identified the missing sandbox entitlements but was marked resolved without the fix being applied.
+
+The `aps-environment` key was never identified as needed for macOS — it was only present in the iOS entitlements. This is the most critical missing piece for sync.
+
+## Proposed Solution
+
+Update `Luego/Luego-macOS.entitlements` to include all required entitlements.
+
+### `Luego/Luego-macOS.entitlements`
+
+The file should contain:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>aps-environment</key>
+    <string>development</string>
+    <key>com.apple.developer.icloud-container-identifiers</key>
+    <array>
+        <string>iCloud.com.esoxjem.Luego</string>
+    </array>
+    <key>com.apple.developer.icloud-services</key>
+    <array>
+        <string>CloudKit</string>
+    </array>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.esoxjem.Luego</string>
+    </array>
+</dict>
+</plist>
+```
+
+**New keys being added:**
+1. `com.apple.security.app-sandbox` — declares sandbox mode explicitly
+2. `com.apple.security.network.client` — allows network access in sandbox
+3. `aps-environment` — enables CloudKit push notifications for sync
+4. `com.apple.security.application-groups` — enables App Group for Share Extension parity
+
+## Acceptance Criteria
+
+- [x] `Luego-macOS.entitlements` contains all 6 entitlement keys listed above
+- [ ] macOS app builds successfully
+- [ ] macOS app launches without sandbox errors in Console.app
+- [ ] Articles added on iPhone appear on macOS after a short delay
+- [ ] Articles added on macOS appear on iPhone after a short delay
+- [ ] SyncStatusObserver shows `.syncing` and `.success` states on macOS
+- [x] Unit tests pass on iOS Simulator (281/281 passed)
+
+## Context
+
+- **Files to modify:** 1 (`Luego/Luego-macOS.entitlements`)
+- **Effort:** Trivial (~5 minutes)
+- **Risk:** None — adding missing entitlements is purely additive
+
+## References
+
+- iOS entitlements (reference): `Luego/Luego.entitlements`
+- Original macOS plan: `docs/plans/2026-01-30-feat-macos-native-support-plan.md` (lines 88-108)
+- Unresolved todo: `todos/003-resolved-p2-missing-sandbox-entitlements.md`
+- CloudKit sync observer: `Luego/Core/DataSources/SyncStatusObserver.swift`
+- CloudKit background mode doc: `docs/solutions/build-errors/cloudkit-remote-notification-background-mode.md`


### PR DESCRIPTION
## Summary

- macOS iCloud sync is broken — articles added on iPhone/iPad don't appear on the Mac app (sync works fine between iPhone and iPad)
- Root cause: `Luego-macOS.entitlements` is missing 4 critical entitlement keys that were specified in the original macOS support plan but never added during implementation
- The most critical missing key is `aps-environment`, which CloudKit needs to register for push notifications that trigger sync

## Changes

Added 4 missing keys to `Luego/Luego-macOS.entitlements`:

| Key | Purpose |
|-----|---------|
| `aps-environment` | Enables CloudKit push notifications for sync |
| `com.apple.security.app-sandbox` | Declares sandbox mode (matches `ENABLE_APP_SANDBOX = YES` build setting) |
| `com.apple.security.network.client` | Allows network access in sandboxed mode |
| `com.apple.security.application-groups` | Enables App Group for Share Extension parity with iOS |

Also includes a plan document at `docs/plans/2026-02-07-fix-macos-icloud-sync-missing-entitlements-plan.md` with the full investigation.

## Testing

> **Note:** I was unable to test this fix locally on macOS due to code signing / provisioning certificate issues. The iOS simulator build and all 281 unit tests pass. You'll need to build and verify iCloud sync on a Mac with the correct developer credentials.

**Suggested test steps:**
1. Build and run on macOS
2. Verify articles from iPhone/iPad appear on the Mac
3. Add an article on Mac and verify it syncs to iPhone/iPad
4. Check Console.app for any sandbox or CloudKit errors

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds 4 missing entitlement keys to `Luego-macOS.entitlements` to fix iCloud sync on macOS: `aps-environment` (CloudKit push notifications), `com.apple.security.app-sandbox`, `com.apple.security.network.client`, and `com.apple.security.application-groups`.

- `aps-environment` enables CloudKit to deliver push notifications that trigger sync when articles are added on iPhone/iPad
- Sandbox entitlements bring macOS entitlements to parity with iOS configuration and align with the `ENABLE_APP_SANDBOX = YES` build setting

**Critical concern**: The sandbox-related entitlements (`app-sandbox` and `network.client`) were deliberately removed in commit `1b2e705` on Jan 31, 2026 to "allow functionality that requires access beyond sandbox restrictions". Re-adding them may reintroduce whatever issue that removal fixed. Verify with the original author what broke with sandboxing enabled before merging.

<h3>Confidence Score: 2/5</h3>

- Risky to merge without verification - conflicts with a deliberate fix from one week ago
- The PR correctly identifies missing entitlements needed for iCloud sync, but re-adds sandbox entitlements that were intentionally removed in commit 1b2e705 (Jan 31, 2026) to fix functionality issues. This creates a direct conflict between two fixes - one for iCloud sync, one for "broader system access". Without understanding what broke with sandboxing enabled, merging could reintroduce that issue.
- Verify `Luego/Luego-macOS.entitlements` doesn't break functionality that required sandbox removal

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Luego/Luego-macOS.entitlements | Re-adds sandbox entitlements that were intentionally removed one week ago; may conflict with previous fix |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant iPhone as iPhone/iPad
    participant iCloud as iCloud CloudKit
    participant Mac as Mac App
    participant APNs as Apple Push Service

    Note over iPhone,Mac: Before Fix (Sync Broken)
    iPhone->>iCloud: Save new article
    iCloud->>APNs: Send push notification
    APNs--xMac: Push fails (no aps-environment)
    Note over Mac: Mac never receives sync event
    Note over Mac: Article doesn't appear

    Note over iPhone,Mac: After Fix (With Entitlements)
    iPhone->>iCloud: Save new article
    iCloud->>APNs: Send push notification
    APNs->>Mac: Deliver push (aps-environment enabled)
    Mac->>iCloud: Fetch changes via network (sandbox + network.client)
    iCloud->>Mac: Return new article data
    Note over Mac: Article appears, sync complete
```

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->