### PR TITLE
Add launch and sync diagnostics logging for CloudKit debugging

### DIFF
--- a/Luego/Core/DI/DIContainer.swift
+++ b/Luego/Core/DI/DIContainer.swift
@@ -61,7 +61,7 @@ final class DIContainer {
     var sdkManager: LuegoSDKManagerProtocol { luegoSDKManager }
 
     private lazy var _syncStatusObserver: SyncStatusObserver = {
-        SyncStatusObserver()
+        SyncStatusObserver(modelContext: modelContext)
     }()
 
     var syncObserver: SyncStatusObserver { _syncStatusObserver }

--- a/LuegoTests/Core/DataSources/SyncStatusObserverTests.swift
+++ b/LuegoTests/Core/DataSources/SyncStatusObserverTests.swift
@@ -1,19 +1,25 @@
 import Testing
 import Foundation
+import SwiftData
 @testable import Luego
 
 @Suite("SyncStatusObserver Tests")
 @MainActor
 struct SyncStatusObserverTests {
+    private func makeObserver() throws -> SyncStatusObserver {
+        let container = try createTestModelContainer()
+        return SyncStatusObserver(modelContext: container.mainContext)
+    }
+
     @Test("initial state is idle")
-    func initialStateIsIdle() async {
-        let observer = SyncStatusObserver()
+    func initialStateIsIdle() async throws {
+        let observer = try makeObserver()
         #expect(observer.state == .idle)
     }
 
     @Test("lastSyncTime starts as nil")
-    func lastSyncTimeStartsNil() async {
-        let observer = SyncStatusObserver()
+    func lastSyncTimeStartsNil() async throws {
+        let observer = try makeObserver()
         #expect(observer.lastSyncTime == nil)
     }
 
@@ -28,8 +34,8 @@ struct SyncStatusObserverTests {
     }
 
     @Test("dismissError does nothing when in idle state")
-    func dismissErrorDoesNothingWhenIdle() async {
-        let observer = SyncStatusObserver()
+    func dismissErrorDoesNothingWhenIdle() async throws {
+        let observer = try makeObserver()
         #expect(observer.state == .idle)
 
         observer.dismissError()


### PR DESCRIPTION
Adds comprehensive logging for macOS CloudKit sync troubleshooting:

- Log iCloud account status and article counts on app launch
- Enhance CloudKit error logging with detailed CKError information
- Log article inventory (total, reading list, favorites, archived) after sync imports
- Update SyncStatusObserver initialization to support article counting

This helps diagnose sync issues on macOS by providing visibility into iCloud connectivity and article state changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds CloudKit/SwiftData diagnostics to help troubleshoot iCloud sync, including:

- A new launch-time task in `LuegoApp` that logs iCloud account status and the current SwiftData `Article` count.
- Enhanced `SyncStatusObserver` logging: CKError-specific details on failure and a post-import inventory log of articles (total/favorites/archived/derived reading list).
- DI wiring + unit test updates so `SyncStatusObserver` is initialized with a `ModelContext` for counting.

The changes integrate at app launch (`.task`) and during CloudKit event notifications (`NSPersistentCloudKitContainer.eventChangedNotification`).

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable, but has a couple correctness issues that can produce misleading diagnostics and duplicate observers/logging.
- Most changes are additive logging and DI plumbing, but (1) `DIContainer` is reconstructed multiple times in `LuegoApp`, which can spawn multiple `SyncStatusObserver` tasks/NotificationCenter subscriptions, and (2) reading list count is derived in a way that is wrong when favorites/archived overlap. Fixing those should make the diagnostics reliable.
- Luego/App/LuegoApp.swift, Luego/Core/DataSources/SyncStatusObserver.swift

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Luego/App/LuegoApp.swift | Adds CloudKit/iCloud status and article count logging on launch via a new SwiftUI task; also introduces a likely bug where `diContainer` is recreated on each access, potentially duplicating observers/work. |
| Luego/Core/DI/DIContainer.swift | Wires `SyncStatusObserver` to accept a `ModelContext` from DI; change is straightforward assuming DIContainer is singleton-like (see LuegoApp usage). |
| Luego/Core/DataSources/SyncStatusObserver.swift | Adds CKError detail logging and post-import article count logging; reading list count derivation can be wrong if buckets overlap. |
| LuegoTests/Core/DataSources/SyncStatusObserverTests.swift | Updates tests to construct SyncStatusObserver with a test ModelContainer; minimal changes. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as LuegoApp
    participant DI as DIContainer
    participant Obs as SyncStatusObserver
    participant NC as NotificationCenter
    participant CK as CKContainer
    participant SD as SwiftData(ModelContext)

    App->>DI: init(modelContext)
    App->>Obs: access diContainer.syncObserver
    Obs->>NC: subscribe(eventChangedNotification)

    App->>CK: accountStatus()
    CK-->>App: CKAccountStatus / error
    App->>SD: fetchCount(Article)
    SD-->>App: count / error

    NC-->>Obs: NSPersistentCloudKitContainer.Event
    alt event.endDate == nil
        Obs->>Obs: updateState(.syncing)
    else event.error != nil
        Obs->>Obs: classifyError + updateState(.error)
        Obs->>Obs: logSyncError(CKError details)
    else success
        Obs->>Obs: updateState(.success)
        opt event.type == .import
            Obs->>SD: fetchCount(total/favorites/archived)
            SD-->>Obs: counts / error
            Obs->>Obs: logArticleCounts
        end
        Obs->>Obs: debounce then updateState(.idle)
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=88101c42-336f-471b-b199-eb08448022fd))

<!-- /greptile_comment -->